### PR TITLE
feat: implement auto-segmentation for audio files longer than 3 minutes

### DIFF
--- a/AudioSegmenter.cs
+++ b/AudioSegmenter.cs
@@ -1,0 +1,173 @@
+using NAudio.Wave;
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace whisper_windows
+{
+    public class AudioSegment
+    {
+        public int SegmentNumber { get; set; }
+        public int TotalSegments { get; set; }
+        public string FilePath { get; set; }
+        public TimeSpan Duration { get; set; }
+    }
+
+    public class AudioSegmenter
+    {
+        private const int MAX_SEGMENT_DURATION_SECONDS = 180; // 3 minutes
+
+        /// <summary>
+        /// Gets the duration of an audio file
+        /// </summary>
+        public static TimeSpan GetAudioDuration(string filePath)
+        {
+            try
+            {
+                using (var reader = new WaveFileReader(filePath))
+                {
+                    return reader.TotalTime;
+                }
+            }
+            catch (Exception ex)
+            {
+                throw new InvalidOperationException($"Failed to read audio duration: {ex.Message}", ex);
+            }
+        }
+
+        /// <summary>
+        /// Determines if audio needs to be segmented
+        /// </summary>
+        public static bool NeedsSegmentation(string filePath)
+        {
+            var duration = GetAudioDuration(filePath);
+            return duration.TotalSeconds > MAX_SEGMENT_DURATION_SECONDS;
+        }
+
+        /// <summary>
+        /// Splits an audio file into equal segments, each under 3 minutes
+        /// </summary>
+        public static List<AudioSegment> SegmentAudio(string inputFilePath, string outputDirectory = null)
+        {
+            if (outputDirectory == null)
+            {
+                outputDirectory = Path.GetDirectoryName(inputFilePath);
+            }
+
+            if (!Directory.Exists(outputDirectory))
+            {
+                Directory.CreateDirectory(outputDirectory);
+            }
+
+            var segments = new List<AudioSegment>();
+            var totalDuration = GetAudioDuration(inputFilePath);
+
+            // Calculate optimal number of segments
+            int segmentCount = (int)Math.Ceiling(totalDuration.TotalSeconds / MAX_SEGMENT_DURATION_SECONDS);
+
+            if (segmentCount <= 1)
+            {
+                // No segmentation needed
+                return segments;
+            }
+
+            // Calculate exact segment duration
+            double segmentDurationSeconds = totalDuration.TotalSeconds / segmentCount;
+
+            using (var reader = new WaveFileReader(inputFilePath))
+            {
+                var waveFormat = reader.WaveFormat;
+
+                for (int i = 0; i < segmentCount; i++)
+                {
+                    long startSample = (long)(i * segmentDurationSeconds * waveFormat.SampleRate);
+                    long endSample = i == segmentCount - 1
+                        ? reader.SampleCount
+                        : (long)((i + 1) * segmentDurationSeconds * waveFormat.SampleRate);
+
+                    long sampleCount = endSample - startSample;
+
+                    string segmentFileName = $"{Path.GetFileNameWithoutExtension(inputFilePath)}_seg_{i + 1}_of_{segmentCount}.wav";
+                    string segmentFilePath = Path.Combine(outputDirectory, segmentFileName);
+
+                    ExtractAudioSegment(inputFilePath, segmentFilePath, startSample, sampleCount);
+
+                    var segmentDuration = TimeSpan.FromSeconds((double)sampleCount / waveFormat.SampleRate);
+
+                    segments.Add(new AudioSegment
+                    {
+                        SegmentNumber = i + 1,
+                        TotalSegments = segmentCount,
+                        FilePath = segmentFilePath,
+                        Duration = segmentDuration
+                    });
+                }
+            }
+
+            return segments;
+        }
+
+        /// <summary>
+        /// Extracts a specific segment from an audio file
+        /// </summary>
+        private static void ExtractAudioSegment(string inputFilePath, string outputFilePath, long startSample, long sampleCount)
+        {
+            try
+            {
+                using (var reader = new WaveFileReader(inputFilePath))
+                {
+                    var waveFormat = reader.WaveFormat;
+                    var bytesPerSample = waveFormat.BitsPerSample / 8 * waveFormat.Channels;
+
+                    // Seek to start position
+                    reader.CurrentTime = TimeSpan.FromSeconds((double)startSample / waveFormat.SampleRate);
+
+                    using (var writer = new WaveFileWriter(outputFilePath, waveFormat))
+                    {
+                        int bufferSize = waveFormat.SampleRate * bytesPerSample; // 1 second buffer
+                        byte[] buffer = new byte[bufferSize];
+                        long samplesRead = 0;
+
+                        while (samplesRead < sampleCount)
+                        {
+                            long samplesToRead = Math.Min(bufferSize / bytesPerSample, sampleCount - samplesRead);
+                            int bytesToRead = (int)(samplesToRead * bytesPerSample);
+
+                            int bytesRead = reader.Read(buffer, 0, bytesToRead);
+                            if (bytesRead == 0)
+                                break;
+
+                            writer.Write(buffer, 0, bytesRead);
+                            samplesRead += bytesRead / bytesPerSample;
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                throw new InvalidOperationException($"Failed to extract audio segment: {ex.Message}", ex);
+            }
+        }
+
+        /// <summary>
+        /// Cleans up temporary segment files
+        /// </summary>
+        public static void CleanupSegments(List<AudioSegment> segments)
+        {
+            foreach (var segment in segments)
+            {
+                try
+                {
+                    if (File.Exists(segment.FilePath))
+                    {
+                        File.Delete(segment.FilePath);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine($"Warning: Failed to cleanup segment {segment.FilePath}: {ex.Message}");
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

This PR implements auto-segmentation for audio files longer than 3 minutes to handle OpenAI Whisper API's duration limitations. Closes #6

## Changes

### New AudioSegmenter Utility Class
- **Audio Duration Detection** - Uses NAudio's WaveFileReader to accurately measure audio length
- **Smart Segmentation** - Calculates optimal segment count for uniform distribution
- **Segment Splitting** - Divides audio into equal segments, each under 3 minutes
- **Resource Management** - Automatic cleanup of temporary segment files

### Enhanced Form1 Audio Processing
- **Adaptive Transcription**:
  - `SendAudioToWhisperAPI()` - Detects long audio and routes to segmentation if needed
  - `HandleSegmentedAudio()` - Orchestrates multi-segment transcription workflow
  - `SendSingleAudioSegment()` - Sends individual segments to Whisper API
  
- **User Feedback**:
  - Progress display: "Segmenting audio..." during processing
  - Per-segment feedback: "Transcribing part X/Y..."
  - Result merging with automatic concatenation

## Features Implemented (Issue #6)

✅ Automatic audio duration detection
✅ Optimal segment count calculation  
✅ Uniform audio splitting (each segment < 3 minutes)
✅ Sequential segment transcription
✅ Result merging and display
✅ Progress feedback to user ("Part 1/3", etc.)
✅ Support for 3-30+ minute audio files
✅ Robust error handling and resource cleanup
✅ Backward compatible with short audio files
✅ Fixed path handling for relative file paths

## Technical Details

**New Files:**
- `AudioSegmenter.cs` - Audio processing utility

**Modified Files:**
- `Form1.cs` - Integration of segmentation logic

**Key Methods:**
- `AudioSegmenter.GetAudioDuration()` - Detect audio length
- `AudioSegmenter.NeedsSegmentation()` - Check if segmentation needed
- `AudioSegmenter.SegmentAudio()` - Split audio file
- `AudioSegmenter.CleanupSegments()` - Remove temp files

**Commits:**
- 119fa3c: feat: implement auto-segmentation for audio files longer than 3 minutes
- fa0a307: fix: improve audio segmentation robustness and handle relative file paths

## Test Plan

- [x] Application builds successfully
- [x] Short audio (< 3 min) processes normally
- [x] Long audio (> 3 min) triggers segmentation
- [x] Progress indicators display correctly
- [x] All segments transcribed successfully
- [x] Results properly merged and displayed
- [x] Temporary files cleaned up after transcription
- [x] Error handling works for edge cases
- [x] Relative and absolute file paths handled correctly
- [x] Application runs on Windows 64-bit

🤖 Generated with Claude Code

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>