### PR TITLE
feat: Improve status indicators and display (issue #9)

### DIFF
--- a/AppStatus.cs
+++ b/AppStatus.cs
@@ -1,0 +1,217 @@
+using System;
+using System.Drawing;
+
+namespace whisper_windows
+{
+    /// <summary>
+    /// Application status states
+    /// </summary>
+    public enum AppStatus
+    {
+        /// <summary>Idle - waiting for user action</summary>
+        Idle,
+        /// <summary>Recording audio from microphone</summary>
+        Recording,
+        /// <summary>Processing recorded audio (preparing for submission)</summary>
+        Processing,
+        /// <summary>Sending audio to API</summary>
+        Sending,
+        /// <summary>Waiting for transcription from API</summary>
+        Transcribing,
+        /// <summary>Transcription completed successfully</summary>
+        Success,
+        /// <summary>An error occurred</summary>
+        Error
+    }
+
+    /// <summary>
+    /// Holds display information for each status state
+    /// </summary>
+    public class StatusInfo
+    {
+        public string Icon { get; set; }
+        public string Text { get; set; }
+        public string TextEn { get; set; }
+        public Color Color { get; set; }
+        public string DetailMessage { get; set; }
+
+        public StatusInfo(string icon, string text, string textEn, Color color, string detailMessage = "")
+        {
+            Icon = icon;
+            Text = text;
+            TextEn = textEn;
+            Color = color;
+            DetailMessage = detailMessage;
+        }
+    }
+
+    /// <summary>
+    /// Manages application status and provides status information
+    /// </summary>
+    public class StatusManager
+    {
+        public event EventHandler<StatusChangedEventArgs> StatusChanged;
+
+        private AppStatus _currentStatus = AppStatus.Idle;
+        private string _detailMessage = "";
+        private int _currentSegment = 0;
+        private int _totalSegments = 0;
+
+        public AppStatus CurrentStatus
+        {
+            get => _currentStatus;
+            private set
+            {
+                if (_currentStatus != value)
+                {
+                    var oldStatus = _currentStatus;
+                    _currentStatus = value;
+                    OnStatusChanged(oldStatus, value);
+                }
+            }
+        }
+
+        public string DetailMessage
+        {
+            get => _detailMessage;
+            private set => _detailMessage = value;
+        }
+
+        public int CurrentSegment => _currentSegment;
+        public int TotalSegments => _totalSegments;
+
+        /// <summary>
+        /// Get status display info for a given status
+        /// </summary>
+        public static StatusInfo GetStatusInfo(AppStatus status)
+        {
+            return status switch
+            {
+                AppStatus.Idle => new StatusInfo("⏸", "就绪", "Ready", Color.FromArgb(100, 100, 100)),
+                AppStatus.Recording => new StatusInfo("🎤", "录制中", "Recording", Color.FromArgb(220, 53, 69)),
+                AppStatus.Processing => new StatusInfo("⚙", "处理中", "Processing", Color.FromArgb(255, 193, 7)),
+                AppStatus.Sending => new StatusInfo("📤", "发送中", "Sending", Color.FromArgb(0, 123, 255)),
+                AppStatus.Transcribing => new StatusInfo("⏳", "转录中", "Transcribing", Color.FromArgb(111, 66, 193)),
+                AppStatus.Success => new StatusInfo("✓", "完成", "Success", Color.FromArgb(40, 167, 69)),
+                AppStatus.Error => new StatusInfo("✗", "错误", "Error", Color.FromArgb(220, 53, 69)),
+                _ => new StatusInfo("?", "未知", "Unknown", Color.Gray)
+            };
+        }
+
+        /// <summary>
+        /// Get the current status info with detail message
+        /// </summary>
+        public StatusInfo GetCurrentStatusInfo()
+        {
+            var info = GetStatusInfo(CurrentStatus);
+            info.DetailMessage = _detailMessage;
+            return info;
+        }
+
+        /// <summary>
+        /// Set status to Idle
+        /// </summary>
+        public void SetIdle()
+        {
+            _detailMessage = "";
+            _currentSegment = 0;
+            _totalSegments = 0;
+            CurrentStatus = AppStatus.Idle;
+        }
+
+        /// <summary>
+        /// Set status to Recording
+        /// </summary>
+        public void SetRecording()
+        {
+            _detailMessage = "按 Ctrl+M 停止录制";
+            CurrentStatus = AppStatus.Recording;
+        }
+
+        /// <summary>
+        /// Set status to Processing
+        /// </summary>
+        public void SetProcessing(string detail = "")
+        {
+            _detailMessage = string.IsNullOrEmpty(detail) ? "正在处理音频..." : detail;
+            CurrentStatus = AppStatus.Processing;
+        }
+
+        /// <summary>
+        /// Set status to Sending with optional file size info
+        /// </summary>
+        public void SetSending(long? fileSizeBytes = null)
+        {
+            if (fileSizeBytes.HasValue)
+            {
+                var sizeMB = fileSizeBytes.Value / (1024.0 * 1024.0);
+                _detailMessage = $"正在发送音频 ({sizeMB:F1} MB)...";
+            }
+            else
+            {
+                _detailMessage = "正在发送音频...";
+            }
+            CurrentStatus = AppStatus.Sending;
+        }
+
+        /// <summary>
+        /// Set status to Transcribing
+        /// </summary>
+        public void SetTranscribing()
+        {
+            _detailMessage = "等待 API 响应...";
+            CurrentStatus = AppStatus.Transcribing;
+        }
+
+        /// <summary>
+        /// Set status to Transcribing with segment progress
+        /// </summary>
+        public void SetTranscribingSegment(int current, int total)
+        {
+            _currentSegment = current;
+            _totalSegments = total;
+            _detailMessage = $"正在转录第 {current}/{total} 段...";
+            CurrentStatus = AppStatus.Transcribing;
+        }
+
+        /// <summary>
+        /// Set status to Success
+        /// </summary>
+        public void SetSuccess(string detail = "")
+        {
+            _detailMessage = string.IsNullOrEmpty(detail) ? "转录完成，已复制到剪贴板" : detail;
+            CurrentStatus = AppStatus.Success;
+        }
+
+        /// <summary>
+        /// Set status to Error
+        /// </summary>
+        public void SetError(string errorMessage)
+        {
+            _detailMessage = errorMessage;
+            CurrentStatus = AppStatus.Error;
+        }
+
+        protected virtual void OnStatusChanged(AppStatus oldStatus, AppStatus newStatus)
+        {
+            StatusChanged?.Invoke(this, new StatusChangedEventArgs(oldStatus, newStatus, _detailMessage));
+        }
+    }
+
+    /// <summary>
+    /// Event args for status change events
+    /// </summary>
+    public class StatusChangedEventArgs : EventArgs
+    {
+        public AppStatus OldStatus { get; }
+        public AppStatus NewStatus { get; }
+        public string DetailMessage { get; }
+
+        public StatusChangedEventArgs(AppStatus oldStatus, AppStatus newStatus, string detailMessage)
+        {
+            OldStatus = oldStatus;
+            NewStatus = newStatus;
+            DetailMessage = detailMessage;
+        }
+    }
+}

--- a/Form1.Designer.cs
+++ b/Form1.Designer.cs
@@ -1,4 +1,4 @@
-﻿namespace whisper_windows
+namespace whisper_windows
 {
     partial class Form1
     {
@@ -39,18 +39,25 @@
             this.label1 = new System.Windows.Forms.Label();
             this.fileSystemWatcher1 = new System.IO.FileSystemWatcher();
             this.settingsButton = new System.Windows.Forms.Button();
+            this.statusPanel = new System.Windows.Forms.Panel();
+            this.statusDetailLabel = new System.Windows.Forms.Label();
+            this.statusIconLabel = new System.Windows.Forms.Label();
+            this.statusTextLabel = new System.Windows.Forms.Label();
+            this.statusProgressBar = new System.Windows.Forms.ProgressBar();
+            this.statusTimer = new System.Windows.Forms.Timer(this.components);
             this.flowLayoutPanel1.SuspendLayout();
+            this.statusPanel.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.fileSystemWatcher1)).BeginInit();
             this.SuspendLayout();
-            // 
+            //
             // timer1
-            // 
+            //
             this.timer1.Tick += new System.EventHandler(this.timer1_Tick);
-            // 
+            //
             // textBox1
-            // 
+            //
             this.textBox1.Dock = System.Windows.Forms.DockStyle.Bottom;
-            this.textBox1.Location = new System.Drawing.Point(0, 67);
+            this.textBox1.Location = new System.Drawing.Point(0, 126);
             this.textBox1.Margin = new System.Windows.Forms.Padding(20, 3, 3, 3);
             this.textBox1.Multiline = true;
             this.textBox1.Name = "textBox1";
@@ -58,9 +65,9 @@
             this.textBox1.Size = new System.Drawing.Size(384, 94);
             this.textBox1.TabIndex = 2;
             this.textBox1.TextChanged += new System.EventHandler(this.textBox1_TextChanged);
-            // 
+            //
             // button1
-            // 
+            //
             this.button1.Location = new System.Drawing.Point(40, 18);
             this.button1.Margin = new System.Windows.Forms.Padding(40, 3, 3, 3);
             this.button1.Name = "button1";
@@ -69,34 +76,93 @@
             this.button1.Text = "button1";
             this.button1.UseVisualStyleBackColor = true;
             this.button1.Click += new System.EventHandler(this.button1_Click);
-            // 
+            //
             // flowLayoutPanel1
-            // 
+            //
             this.flowLayoutPanel1.Anchor = System.Windows.Forms.AnchorStyles.None;
             this.flowLayoutPanel1.Controls.Add(this.label1);
             this.flowLayoutPanel1.Controls.Add(this.button1);
             this.flowLayoutPanel1.FlowDirection = System.Windows.Forms.FlowDirection.TopDown;
-            this.flowLayoutPanel1.Location = new System.Drawing.Point(115, 7);
+            this.flowLayoutPanel1.Location = new System.Drawing.Point(115, 65);
             this.flowLayoutPanel1.Name = "flowLayoutPanel1";
             this.flowLayoutPanel1.Size = new System.Drawing.Size(159, 54);
             this.flowLayoutPanel1.TabIndex = 4;
-            // 
-            // 
+            //
             // settingsButton
-            // 
+            //
             this.settingsButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.settingsButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.settingsButton.Font = new System.Drawing.Font("Segoe UI", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
-            this.settingsButton.Location = new System.Drawing.Point(346, 8);
+            this.settingsButton.Location = new System.Drawing.Point(346, 68);
             this.settingsButton.Name = "settingsButton";
             this.settingsButton.Size = new System.Drawing.Size(30, 30);
             this.settingsButton.TabIndex = 5;
-            this.settingsButton.Text = "⚙";
+            this.settingsButton.Text = "\u2699";
             this.settingsButton.UseVisualStyleBackColor = true;
             this.settingsButton.Click += new System.EventHandler(this.settingsButton_Click);
-            // 
+            //
+            // statusPanel
+            //
+            this.statusPanel.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(245)))), ((int)(((byte)(245)))), ((int)(((byte)(245)))));
+            this.statusPanel.Controls.Add(this.statusIconLabel);
+            this.statusPanel.Controls.Add(this.statusTextLabel);
+            this.statusPanel.Controls.Add(this.statusDetailLabel);
+            this.statusPanel.Controls.Add(this.statusProgressBar);
+            this.statusPanel.Dock = System.Windows.Forms.DockStyle.Top;
+            this.statusPanel.Location = new System.Drawing.Point(0, 0);
+            this.statusPanel.Name = "statusPanel";
+            this.statusPanel.Size = new System.Drawing.Size(384, 60);
+            this.statusPanel.TabIndex = 6;
+            //
+            // statusIconLabel
+            //
+            this.statusIconLabel.Font = new System.Drawing.Font("Segoe UI Emoji", 20F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
+            this.statusIconLabel.Location = new System.Drawing.Point(12, 8);
+            this.statusIconLabel.Name = "statusIconLabel";
+            this.statusIconLabel.Size = new System.Drawing.Size(45, 40);
+            this.statusIconLabel.TabIndex = 0;
+            this.statusIconLabel.Text = "\u23F8";
+            this.statusIconLabel.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            //
+            // statusTextLabel
+            //
+            this.statusTextLabel.AutoSize = true;
+            this.statusTextLabel.Font = new System.Drawing.Font("Segoe UI", 14F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
+            this.statusTextLabel.Location = new System.Drawing.Point(60, 8);
+            this.statusTextLabel.Name = "statusTextLabel";
+            this.statusTextLabel.Size = new System.Drawing.Size(50, 25);
+            this.statusTextLabel.TabIndex = 1;
+            this.statusTextLabel.Text = "\u5C31\u7EEA";
+            //
+            // statusDetailLabel
+            //
+            this.statusDetailLabel.AutoSize = true;
+            this.statusDetailLabel.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
+            this.statusDetailLabel.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(100)))), ((int)(((byte)(100)))), ((int)(((byte)(100)))));
+            this.statusDetailLabel.Location = new System.Drawing.Point(60, 35);
+            this.statusDetailLabel.Name = "statusDetailLabel";
+            this.statusDetailLabel.Size = new System.Drawing.Size(150, 15);
+            this.statusDetailLabel.TabIndex = 2;
+            this.statusDetailLabel.Text = "\u6309 Ctrl+M \u5F00\u59CB\u5F55\u5236";
+            //
+            // statusProgressBar
+            //
+            this.statusProgressBar.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.statusProgressBar.Location = new System.Drawing.Point(280, 25);
+            this.statusProgressBar.MarqueeAnimationSpeed = 30;
+            this.statusProgressBar.Name = "statusProgressBar";
+            this.statusProgressBar.Size = new System.Drawing.Size(90, 10);
+            this.statusProgressBar.Style = System.Windows.Forms.ProgressBarStyle.Marquee;
+            this.statusProgressBar.TabIndex = 3;
+            this.statusProgressBar.Visible = false;
+            //
+            // statusTimer
+            //
+            this.statusTimer.Interval = 2000;
+            this.statusTimer.Tick += new System.EventHandler(this.statusTimer_Tick);
+            //
             // label1
-            // 
+            //
             this.label1.AutoSize = true;
             this.label1.Location = new System.Drawing.Point(60, 0);
             this.label1.Margin = new System.Windows.Forms.Padding(60, 0, 3, 0);
@@ -104,23 +170,26 @@
             this.label1.Size = new System.Drawing.Size(34, 15);
             this.label1.TabIndex = 4;
             this.label1.Text = "00:00";
-            // 
+            //
             // fileSystemWatcher1
-            // 
+            //
             this.fileSystemWatcher1.EnableRaisingEvents = true;
             this.fileSystemWatcher1.SynchronizingObject = this;
-            // 
+            //
             // Form1
-            // 
+            //
             this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(384, 161);
+            this.ClientSize = new System.Drawing.Size(384, 220);
+            this.Controls.Add(this.statusPanel);
             this.Controls.Add(this.flowLayoutPanel1);
             this.Controls.Add(this.settingsButton);
             this.Controls.Add(this.textBox1);
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.Name = "Form1";
             this.Text = "Whisper Window";
+            this.statusPanel.ResumeLayout(false);
+            this.statusPanel.PerformLayout();
             this.flowLayoutPanel1.ResumeLayout(false);
             this.flowLayoutPanel1.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.fileSystemWatcher1)).EndInit();
@@ -137,5 +206,11 @@
         private Label label1;
         private FileSystemWatcher fileSystemWatcher1;
         private Button settingsButton;
+        private Panel statusPanel;
+        private Label statusIconLabel;
+        private Label statusTextLabel;
+        private Label statusDetailLabel;
+        private ProgressBar statusProgressBar;
+        private System.Windows.Forms.Timer statusTimer;
     }
 }


### PR DESCRIPTION
## Summary

Implements comprehensive status indicators and display for better user experience, addressing issue #9.

- **New AppStatus enum** with 7 states: Idle, Recording, Processing, Sending, Transcribing, Success, Error
- **StatusManager class** with event-based status change notifications
- **Visual status panel** at top of main window with icon, text, detail message, and progress indicator
- **Real-time status updates** throughout recording and transcription flow
- **Multi-segment progress display** (e.g., "正在转录第 2/3 段...")

### UI Changes
- Added status panel (60px height) docked at top of window
- Large emoji status icon (⏸ 🎤 ⚙ 📤 ⏳ ✓ ✗)
- Bold status text with color coding per state
- Detail message showing operation progress
- Animated marquee progress bar for long operations
- Form height increased to accommodate new status panel

### Status State Machine
```
Idle → Recording → Processing → Sending → Transcribing → Success → Idle
                                                       → Error
```

## Test plan

- [ ] Start recording - verify status shows "🎤 录制中" with red color
- [ ] Verify recording duration updates in status detail
- [ ] Stop recording - verify status transitions through Processing → Sending → Transcribing
- [ ] Verify progress bar appears during async operations
- [ ] Complete transcription - verify "✓ 完成" shows briefly then returns to Idle
- [ ] Test error handling - verify "✗ 错误" with error message displayed
- [ ] Test multi-segment audio - verify segment progress display

Closes #9

🤖 Generated with [Claude Code](https://claude.ai/code)